### PR TITLE
Add optional class-weighted loss for imbalanced training

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -264,7 +264,8 @@ def prepare_finetuning_args(machine=None):
         'dist_url': 'env://',
         'enable_deepspeed': False,
         ### solo per pretraining,
-        'normlize_target': True
+        'normlize_target': True,
+        'use_class_weight': False
     }
     # user argument values
 
@@ -301,6 +302,7 @@ def prepare_finetuning_args(machine=None):
         'decoder_depth': 4,
         'testing_epochs': 1,
         'cloudy': False,
+        'use_class_weight': False,
 
         'epochs': 500,
         'start_epoch_for_saving_best_ckpt': 50,  # dopo 50 epoche inizia a salvare il best checkpoint


### PR DESCRIPTION
## Summary
- add `use_class_weight` option in configuration
- compute class-balanced weights from training dataset
- apply weights in CrossEntropyLoss when enabled

## Testing
- `python -m py_compile classification.py arguments.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa082fa4b083338f6427711cae1c44