### PR TITLE
Add cyclone center tracking dataset and training utilities

### DIFF
--- a/dataset/tracking_dataset.py
+++ b/dataset/tracking_dataset.py
@@ -1,0 +1,61 @@
+import os
+from typing import Tuple
+
+import torch
+from torch.utils.data import Dataset
+from torchvision import transforms
+
+from .datasets import MedicanesClsDataset
+
+
+class MedicanesTrackDataset(MedicanesClsDataset):
+    """Dataset for cyclone tracking.
+
+    This dataset reuses :class:`MedicanesClsDataset` to load the video
+    tiles but filters the entries so that only cyclonic tiles
+    (``label == 1``) are kept.  Each sample returns the video tensor and
+    the coordinates of the cyclone centre at the **last frame** of the
+    tile.
+
+    The annotation CSV is expected to contain at least the columns
+    ``path``, ``label`` and two coordinate columns (default
+    ``lon`` and ``lat``).  Coordinate values are returned as a tensor of
+    shape ``[2]`` ordered as ``(lon, lat)``.
+    """
+
+    def __init__(
+        self,
+        anno_path: str,
+        data_root: str = "",
+        clip_len: int = 16,
+        transform: transforms.Compose | None = None,
+        lon_col: str = "lon",
+        lat_col: str = "lat",
+    ) -> None:
+        super().__init__(
+            anno_path=anno_path,
+            data_root=data_root,
+            mode="train",
+            clip_len=clip_len,
+            transform=transform,
+        )
+
+        # Keep only the cyclonic tiles (label == 1)
+        if "label" in self.df.columns:
+            self.df = self.df[self.df["label"] == 1].reset_index(drop=True)
+
+        # Columns containing the coordinates of the last frame
+        if lon_col not in self.df.columns or lat_col not in self.df.columns:
+            raise ValueError(
+                f"CSV must contain columns '{lon_col}' and '{lat_col}' for coordinates"
+            )
+        self.lon_col = lon_col
+        self.lat_col = lat_col
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor, str]:
+        video, _label_unused, folder_path = super().__getitem__(idx)
+        row = self.df.iloc[idx]
+        coords = torch.tensor(
+            [row[self.lon_col], row[self.lat_col]], dtype=torch.float32
+        )
+        return video, coords, folder_path

--- a/engine_for_tracking.py
+++ b/engine_for_tracking.py
@@ -1,0 +1,73 @@
+"""Training utilities for cyclone center tracking."""
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import torch
+
+import utils
+
+
+def train_one_epoch(
+    model: torch.nn.Module,
+    criterion: torch.nn.Module,
+    data_loader: Iterable,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    epoch: int,
+    max_norm: float = 0,
+    log_writer: Optional[utils.TensorboardLogger] = None,
+) -> dict:
+    """Train for a single epoch."""
+    # ensure different shuffles across workers when using DistributedSampler
+    if hasattr(data_loader, "sampler") and hasattr(data_loader.sampler, "set_epoch"):
+        data_loader.sampler.set_epoch(epoch)
+
+    model.train()
+    metric_logger = utils.MetricLogger(delimiter="  ")
+    header = f"Epoch: [{epoch}]"
+    for samples, target, _ in metric_logger.log_every(data_loader, 20, header):
+        samples = samples.to(device)
+        target = target.to(device)
+
+        output = model(samples)
+        loss = criterion(output, target)
+
+        optimizer.zero_grad()
+        loss.backward()
+        if max_norm > 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+        optimizer.step()
+
+        metric_logger.update(loss=loss.item())
+        if log_writer is not None:
+            log_writer.update(loss=loss.item(), head="loss")
+            log_writer.set_step()
+
+    # gather the stats from all processes
+    metric_logger.synchronize_between_processes()
+    return {k: meter.global_avg for k, meter in metric_logger.meters.items()}
+
+
+@torch.no_grad()
+def evaluate(
+    model: torch.nn.Module,
+    criterion: torch.nn.Module,
+    data_loader: Iterable,
+    device: torch.device,
+) -> dict:
+    """Evaluate the model."""
+    model.eval()
+    metric_logger = utils.MetricLogger(delimiter="  ")
+    header = "Test:"
+    for samples, target, _ in metric_logger.log_every(data_loader, 20, header):
+        samples = samples.to(device)
+        target = target.to(device)
+
+        output = model(samples)
+        loss = criterion(output, target)
+
+        metric_logger.update(loss=loss.item())
+
+    metric_logger.synchronize_between_processes()
+    return {k: meter.global_avg for k, meter in metric_logger.meters.items()}

--- a/models/tracking_model.py
+++ b/models/tracking_model.py
@@ -1,0 +1,37 @@
+import torch.nn as nn
+from timm.models import create_model
+from timm.models.layers import trunc_normal_
+
+
+class RegressionHead(nn.Module):
+    """Simple regression head for cyclone coordinate prediction."""
+    def __init__(self, embed_dim: int, out_dim: int) -> None:
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.LayerNorm(embed_dim),
+            nn.Linear(embed_dim, out_dim),
+        )
+        trunc_normal_(self.mlp[1].weight, std=0.02)
+        nn.init.constant_(self.mlp[1].bias, 0.)
+
+    def forward(self, x):
+        return self.mlp(x)
+
+
+def create_tracking_model(model_name: str, init_ckpt: str = "", num_outputs: int = 2, **kwargs) -> nn.Module:
+    """Build a model for cyclone tracking starting from a classification checkpoint.
+
+    This function loads the specified transformer architecture with weights
+    from ``init_ckpt`` (if provided) while discarding the original
+    classification head.  A new :class:`RegressionHead` with ``num_outputs``
+    units is attached for coordinate regression.
+    """
+    extra_kwargs = dict(num_classes=0, **kwargs)
+    if init_ckpt:
+        extra_kwargs["init_ckpt"] = init_ckpt
+        model = create_model(model_name, pretrained=True, **extra_kwargs)
+    else:
+        model = create_model(model_name, pretrained=False, **extra_kwargs)
+
+    model.head = RegressionHead(model.embed_dim, num_outputs)
+    return model

--- a/tracking.py
+++ b/tracking.py
@@ -1,0 +1,184 @@
+"""Entry point for cyclone centre tracking training."""
+import argparse
+import json
+import os
+import time
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.utils.data import DataLoader, DistributedSampler
+from arguments import prepare_finetuning_args
+from optim_factory import create_optimizer
+from dataset.tracking_dataset import MedicanesTrackDataset
+from engine_for_tracking import train_one_epoch, evaluate
+from models.tracking_model import create_tracking_model
+import utils
+from utils import setup_for_distributed
+
+
+def launch_tracking(terminal_args: argparse.Namespace) -> None:
+    """Launch the training process for the tracking task."""
+    args = prepare_finetuning_args(machine=terminal_args.on)
+    args.nb_classes = 2  # two regression outputs: lon and lat
+    args.train_path = terminal_args.train_path
+    args.test_path = terminal_args.test_path
+    args.data_root = terminal_args.data_root
+    if getattr(terminal_args, "init_ckpt", None):
+        args.init_ckpt = terminal_args.init_ckpt
+
+    seed = args.seed
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+
+    # --------------------------- distributed setup ---------------------------
+    rank, local_rank, world_size, _, _ = utils.get_resources()
+    if world_size > 1:
+        dist.init_process_group("nccl", rank=rank, world_size=world_size)
+        args.distributed = True
+    else:
+        args.distributed = False
+    if args.device == "cuda":
+        torch.cuda.set_device(local_rank)
+        args.gpu = local_rank
+        args.world_size = world_size
+        args.rank = rank
+        device = torch.device(f"cuda:{local_rank}")
+    else:
+        device = torch.device("cpu")
+        args.gpu = None
+        args.world_size = 1
+        args.rank = 0
+
+    if args.log_dir and not os.path.exists(args.log_dir):
+        os.makedirs(args.log_dir)
+    setup_for_distributed(rank == 0)
+
+    # ------------------------------- datasets -------------------------------
+    train_dataset = MedicanesTrackDataset(
+        args.train_path,
+        data_root=args.data_root,
+        clip_len=args.num_frames,
+    )
+    test_dataset = MedicanesTrackDataset(
+        args.test_path,
+        data_root=args.data_root,
+        clip_len=args.num_frames,
+    )
+
+    sampler_train = DistributedSampler(
+        train_dataset, num_replicas=world_size, rank=rank, shuffle=True
+    )
+    sampler_test = DistributedSampler(
+        test_dataset, num_replicas=world_size, rank=rank, shuffle=False
+    )
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_mem,
+        drop_last=True,
+        sampler=sampler_train,
+        persistent_workers=True,
+    )
+    test_loader = DataLoader(
+        test_dataset,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_mem,
+        drop_last=False,
+        sampler=sampler_test,
+        persistent_workers=True,
+    )
+
+    # ------------------------------- model ---------------------------------
+    model_kwargs = args.__dict__.copy()
+    for k in ["model", "init_ckpt", "nb_classes"]:
+        model_kwargs.pop(k, None)
+    model = create_tracking_model(
+        args.model,
+        init_ckpt=getattr(args, "init_ckpt", ""),
+        num_outputs=args.nb_classes,
+        drop_path_rate=args.drop_path,
+        **model_kwargs,
+    )
+    model.to(device)
+    model_without_ddp = model
+    if args.distributed:
+        model = torch.nn.parallel.DistributedDataParallel(
+            model, device_ids=[args.gpu], output_device=args.gpu
+        )
+        model_without_ddp = model.module
+
+    criterion = nn.MSELoss()
+    optimizer = create_optimizer(args, model_without_ddp)
+
+    best_loss = float("inf")
+    start_time = time.time()
+    for epoch in range(args.start_epoch, args.epochs):
+        train_stats = train_one_epoch(
+            model, criterion, train_loader, optimizer, device, epoch
+        )
+        val_stats = evaluate(model, criterion, test_loader, device)
+
+        val_loss = val_stats.get("loss", float("inf"))
+        if args.output_dir and val_loss < best_loss and args.rank == 0:
+            best_loss = val_loss
+            checkpoint_path = os.path.join(args.output_dir, "checkpoint-best.pth")
+            torch.save(
+                {
+                    "model": model_without_ddp.state_dict(),
+                    "optimizer": optimizer.state_dict(),
+                    "epoch": epoch,
+                    "args": args.__dict__,
+                },
+                checkpoint_path,
+            )
+            print(f"[INFO] Best checkpoint saved at {checkpoint_path}")
+
+        log_stats = {
+            "epoch": epoch,
+            **{f"train_{k}": v for k, v in train_stats.items()},
+            **{f"val_{k}": v for k, v in val_stats.items()},
+        }
+        if args.output_dir and args.rank == 0:
+            log_path = os.path.join(args.output_dir, "log.txt")
+            with open(log_path, "a") as f:
+                f.write(
+                    json.dumps(
+                        {k: (round(v, 4) if isinstance(v, float) else v) for k, v in log_stats.items()}
+                    )
+                    + "\n"
+                )
+
+    if args.output_dir and args.rank == 0:
+        ckpt = {
+            "model": model_without_ddp.state_dict(),
+            "optimizer": optimizer.state_dict(),
+            "epoch": args.epochs,
+            "args": args.__dict__,
+        }
+        torch.save(ckpt, os.path.join(args.output_dir, "checkpoint-last.pth"))
+    total_time = time.time() - start_time
+    total_time_str = str(time.strftime('%H:%M:%S', time.gmtime(total_time)))
+    print(f"Training time {total_time_str}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("Cyclone centre tracking")
+    parser.add_argument("--train_path", required=True, help="CSV with training data")
+    parser.add_argument("--test_path", required=True, help="CSV with test data")
+    parser.add_argument("--data_root", default="", help="Root folder for video tiles")
+    parser.add_argument("--init_ckpt", default="", help="Checkpoint to load model weights")
+    parser.add_argument(
+        "--on", default=None, help="Machine preset for argument utilities",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    parsed = parse_args()
+    launch_tracking(parsed)
+


### PR DESCRIPTION
## Summary
- introduce `MedicanesTrackDataset` for cyclone tiles providing last-frame centre coordinates
- add lightweight training/evaluation engine for tracking
- create `tracking.py` entry script using existing checkpoints, distributed data loading, and best-checkpoint saving
- add `create_tracking_model` that strips the classification head and attaches a small regression head for coordinate prediction

## Testing
- `python -m py_compile dataset/tracking_dataset.py engine_for_tracking.py tracking.py models/tracking_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb0167cc8883338bbedc59f8933b7b